### PR TITLE
Error in `detect_blinks_velocity()`

### DIFF
--- a/pypillometry/signal/preproc.py
+++ b/pypillometry/signal/preproc.py
@@ -3,6 +3,7 @@ preproc.py
 ==========
 
 preprocessing functions (blinks, smoothing, missing data...)
+21.10.2025 (Josephine) Added fix to detect_blinks_velocity() line 123
 """
 import numpy as np
 import scipy.optimize
@@ -119,7 +120,8 @@ def detect_blinks_velocity(sy, smooth_winsize, vel_onset, vel_offset, min_onset_
     onsets_ixx=np.r_[np.diff(onsets),10]>1
     onsets_len=np.diff(np.r_[0,np.where(onsets_ixx)[0]+1])
     onsets=onsets[:-1][onsets_ixx[:-1]]
-    onsets=onsets[onsets_len>min_onset_len]
+    onsets_len=onsets_len[:len(onsets)]            ## truncate onsets_len to the length of onsets to avoid IndexError in line 124
+    onsets=onsets[onsets_len>min_onset_len]        ## will produce IndexError since len(onsets)!=len(onsets_len)
     logger.debug(f"After filtering, {len(onsets)} onsets remain")
 
     ## offset finding


### PR DESCRIPTION
Minimal script to reproduce:

```python
import sys, os
sys.path.insert(0,"..") # this is not needed if you have installed pypillometry
import pypillometry as pp
print(pp.__package_path__) # check that correct version is being used
pp.logging_set_level("DEBUG")

# PR #27
pp.get_available_datasets()
d = pp.get_example_data("rlmw_002_short")
d.pupil_blinks_detect()
```

The error is

```
File ~/Dropbox/work/projects/pupil/pypillometry/dev/../pypillometry/signal/preproc.py:122, in detect_blinks_velocity(sy, smooth_winsize, vel_onset, vel_offset, min_onset_len, min_offset_len)
    [120](https://file+.vscode-resource.vscode-cdn.net/home/mmi041/work/projects/pupil/pypillometry/dev/~/Dropbox/work/projects/pupil/pypillometry/pypillometry/signal/preproc.py:120) onsets_len=np.diff(np.r_[0,np.where(onsets_ixx)[0]+1])
    [121](https://file+.vscode-resource.vscode-cdn.net/home/mmi041/work/projects/pupil/pypillometry/dev/~/Dropbox/work/projects/pupil/pypillometry/pypillometry/signal/preproc.py:121) onsets=onsets[:-1][onsets_ixx[:-1]]
--> [122](https://file+.vscode-resource.vscode-cdn.net/home/mmi041/work/projects/pupil/pypillometry/dev/~/Dropbox/work/projects/pupil/pypillometry/pypillometry/signal/preproc.py:122) onsets=onsets[onsets_len>min_onset_len]
    [123](https://file+.vscode-resource.vscode-cdn.net/home/mmi041/work/projects/pupil/pypillometry/dev/~/Dropbox/work/projects/pupil/pypillometry/pypillometry/signal/preproc.py:123) logger.debug(f"After filtering, {len(onsets)} onsets remain")
    [125](https://file+.vscode-resource.vscode-cdn.net/home/mmi041/work/projects/pupil/pypillometry/dev/~/Dropbox/work/projects/pupil/pypillometry/pypillometry/signal/preproc.py:125) ## offset finding

IndexError: boolean index did not match indexed array along dimension 0; dimension is 58 but corresponding boolean dimension is 59
```